### PR TITLE
Include declaration file in published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.js
+*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 karma.conf.*
 tests.*
 default.nix
+*.ts
+tsconfig.json
+!index.d.ts

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
 export type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
-interface JsonMap {
+export interface JsonMap {
   [key: string]: AnyJson;
 }
-interface JsonArray extends Array<AnyJson> {}
+export interface JsonArray extends Array<AnyJson> {}
 
 export type ObjPath = (string | number)[];
 export type DiffInsert = [ObjPath, any];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "target": "es6",
     "sourceMap": false,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "declaration": true
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
I came into some issues when using this module in a project using Webpack and TypeScript. I think that Webpack was trying to compile the included `index.ts` rather than use the already provided `index.js`. I did try monkeying around with my webpack and tsconfig, but to no avail. I found that going into `node_modules/json-delta` and manually running `tsc --declaration` fixed this issue. To save anybody else the bother, this commit should prevent it happening again in the future.

- Ensures that declaration files are built by `tsc` by adding `declaration: true` to `tsconfig.json`
- Fixes a compilation error by exporting `JsonMap` and `JsonArray` interfaces
- Ensures that declaration files *are not* committed to version control by including them in `.gitignore`
- Ensures that *only* index.d.ts is shipped to NPM by adding entries to `.npmignore`